### PR TITLE
feat: allow config via script data attributes

### DIFF
--- a/examples/general/button.html
+++ b/examples/general/button.html
@@ -11,7 +11,11 @@
 
     <!-- 依赖：jQuery + FFS 入口（自动加载组件资源） -->
     <script src="../../assets/jquery/3.7.1.min.js"></script>
-    <script src="../../ffs-ui.js" mode="debug"></script>
+    <!-- 可以通过 data-base、data-autoload、data-debug 等属性配置 FFS-UI -->
+    <script src="../../ffs-ui.js"
+            data-base="../../"
+            data-autoload="true"
+            data-debug="true"></script>
 
     <style>
         /* 仅用于演示页的悬浮主题切换按钮外观 */
@@ -34,6 +38,8 @@
 <body>
     <div class="container">
         <h1>按钮组件</h1>
+        <p>通过在引入 FFS-UI 的 <code>&lt;script&gt;</code> 标签上添加
+            <code>data-base</code>、<code>data-autoload</code>、<code>data-debug</code> 等属性可以自定义配置。</p>
 
         <!-- 基础按钮 -->
         <section>

--- a/ffs-ui.js
+++ b/ffs-ui.js
@@ -9,13 +9,27 @@
     const currentScript = document.currentScript;
     const scriptPath = currentScript ? currentScript.src : '';
     const basePath = scriptPath.substring(0, scriptPath.lastIndexOf('/') + 1);
-    const debugMode = currentScript && currentScript.getAttribute('mode') === 'debug';
 
-    const config = {
+    // 从当前 script 标签的 data-* 属性读取配置
+    const dataset = currentScript ? { ...currentScript.dataset } : {};
+    const datasetConfig = {};
+    for (const [key, value] of Object.entries(dataset)) {
+        // 转换布尔值字符串为布尔类型
+        if (value === 'true') datasetConfig[key] = true;
+        else if (value === 'false') datasetConfig[key] = false;
+        else datasetConfig[key] = value;
+    }
+    // data-base => baseUrl
+    if (datasetConfig.base !== undefined) {
+        datasetConfig.baseUrl = datasetConfig.base;
+        delete datasetConfig.base;
+    }
+
+    const config = Object.assign({
         baseUrl: basePath,
         autoload: true,
-        debug: debugMode
-    };
+        debug: currentScript && currentScript.getAttribute('mode') === 'debug'
+    }, datasetConfig);
 
     if (config.debug) {
         console.log('FFS-UI 初始化开始，调试模式已开启');


### PR DESCRIPTION
## Summary
- merge data-base, data-autoload, data-debug from script tag into FFS config
- document data-* configuration options in button example

## Testing
- `node --check ffs-ui.js`


------
https://chatgpt.com/codex/tasks/task_e_68a07f5f45e8832eab7736761f0d32b2