### PR TITLE
Track component load state after resources resolve

### DIFF
--- a/scripts/ffs-components.js
+++ b/scripts/ffs-components.js
@@ -227,6 +227,7 @@
                 }
 
                 await Promise.all(tasks);
+                component.loaded = true;
 
                 if (window.FFS.debug.isEnabled()) {
                     window.FFS.debug.log(`组件 ${name} 加载成功`);


### PR DESCRIPTION
## Summary
- Mark components as loaded after parallel CSS/JS fetching
- Keep success debug logging for loaded components

## Testing
- `node tests/loadComponent.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0a3021930832e883a3010621092ee